### PR TITLE
Demand Queries for Generic Domains

### DIFF
--- a/pysats/generic_wrapper.py
+++ b/pysats/generic_wrapper.py
@@ -1,0 +1,200 @@
+from pysats.simple_model import SimpleModel
+
+from jnius import (
+    JavaClass,
+    MetaJavaClass,
+    JavaMethod,
+    JavaMultipleMethod,
+    cast,
+    autoclass,
+)
+from torch.distributed.autograd import context
+
+Random = autoclass("java.util.Random")
+HashSet = autoclass("java.util.HashSet")
+LinkedList = autoclass("java.util.LinkedList")
+HashSet = autoclass("java.util.HashSet")
+Bundle = autoclass("org.marketdesignresearch.mechlib.core.Bundle")
+BundleEntry = autoclass("org.marketdesignresearch.mechlib.core.BundleEntry")
+LinkedHashMap = autoclass("java.util.LinkedHashMap")
+Price = autoclass("org.marketdesignresearch.mechlib.core.price.Price")
+LinearPrices = autoclass("org.marketdesignresearch.mechlib.core.price.LinearPrices")
+SizeBasedUniqueRandomXOR = autoclass(
+    "org.spectrumauctions.sats.core.bidlang.xor.SizeBasedUniqueRandomXOR"
+)
+JavaUtilRNGSupplier = autoclass(
+    "org.spectrumauctions.sats.core.util.random.JavaUtilRNGSupplier"
+)
+
+class GenericWrapper(SimpleModel):
+    def __init__(self, model):
+        self._pysats_model = model
+        self.population = model.population
+        self.goods = {}
+        self.goods_supply = []
+        self.good_to_licence = {}
+        self.licence_to_good = {}
+        self.mip_path = model.mip_path
+        self.efficient_allocation = None
+
+        world = self.population[0].getWorld()
+        self._bidder_list = model._bidder_list
+
+        # Store bidders
+        bidderator = self._bidder_list.iterator()
+        count = 0
+        while bidderator.hasNext():
+            bidder = bidderator.next()
+            self.population[count] = bidder
+            count += 1
+
+        # Store goods
+        self._good_to_id = {}
+        self.licence_to_good = [0 for g in self._pysats_model.get_good_ids()]
+        goods_iterator = world.getAllGenericDefinitions().iterator()
+        count = 0
+        while goods_iterator.hasNext():
+            good = goods_iterator.next()
+            self.goods[count] = good
+            self._good_to_id[good.getName()] = count
+            self.goods_supply.append(good.getQuantity())
+            # good to licence mapping
+            contained_goods_iterator = good.containedGoods().iterator()
+            licenceIds = []
+            while contained_goods_iterator.hasNext():
+                licence = contained_goods_iterator.next()
+                licenceIds.append(licence.getLongId())
+                self.licence_to_good[licence.getLongId()] = count
+            self.good_to_licence[count] = licenceIds
+            count += 1
+
+        # licence to good mapping
+
+    def get_best_bundles(
+        self, bidder_id, price_vector, max_number_of_bundles, allow_negative=False
+    ):
+        assert len(price_vector) == len(self.goods.keys())
+        bidder = self.population[bidder_id]
+        prices_map = LinkedHashMap()
+        index = 0
+        for good in self.goods.values():
+            prices_map.put(good, Price.of(price_vector[index]))
+            index += 1
+        bundles = bidder.getBestBundles(
+            LinearPrices(prices_map), max_number_of_bundles, allow_negative
+        )
+        result = []
+        for bundle in bundles:
+            bundle_vector = []
+            for i in range(len(price_vector)):
+                bundle_vector.append(bundle.countGood(self.goods[i]))
+            result.append(bundle_vector)
+        return result
+
+    def get_efficient_allocation(self, display_output=False):
+        if self.efficient_allocation:
+            return self.efficient_allocation, sum(
+                [
+                    self.efficient_allocation[bidder_id]["value"]
+                    for bidder_id in self.efficient_allocation.keys()
+                ]
+            )
+
+        mip = autoclass(self.mip_path)(self._bidder_list)
+        mip.setDisplayOutput(display_output)
+
+        allocation = mip.calculateAllocation()
+
+        self.efficient_allocation = {}
+
+        for bidder_id, bidder in self.population.items():
+            self.efficient_allocation[bidder_id] = {}
+            self.efficient_allocation[bidder_id]["good_ids"] = []
+            self.efficient_allocation[bidder_id]["good_count"] = []
+            bidder_allocation = allocation.allocationOf(bidder)
+            good_iterator = (
+                bidder_allocation.getBundle().getBundleEntries().iterator()
+            )
+            while good_iterator.hasNext():
+                entry = good_iterator.next()
+                self.efficient_allocation[bidder_id]["good_ids"].append(
+                    self._good_to_id[entry.getGood().getName()]
+                )
+                self.efficient_allocation[bidder_id]["good_count"].append(entry.getAmount())
+
+            self.efficient_allocation[bidder_id][
+                "value"
+            ] = bidder_allocation.getValue().doubleValue()
+
+        return (
+            self.efficient_allocation,
+            allocation.getTotalAllocationValue().doubleValue(),
+        )
+
+    def get_uniform_random_bids(self, bidder_id, number_of_bids, seed=None):
+        bidder = self.population[bidder_id]
+        goods = LinkedList()
+        for good in self.goods.values():
+            goods.add(good)
+        if seed:
+            random = Random(seed)
+        else:
+            random = Random()
+
+        bids = []
+        for i in range(number_of_bids):
+            bid = []
+            bundle = bidder.getAllocationLimit().getUniformRandomBundle(random, goods)
+            for good_id, good in self.goods.items():
+                bid.append(bundle.countGood(self.goods[i]))
+            bid.append(bidder.getValue(bundle).doubleValue())
+            bids.append(bid)
+        return bids
+
+    def get_random_bids(
+            self,
+            bidder_id,
+            number_of_bids,
+            seed=None,
+            mean_bundle_size=9,
+            standard_deviation_bundle_size=4.5,
+    ):
+        bidder = self.population[bidder_id]
+        if seed:
+            rng = JavaUtilRNGSupplier(seed)
+        else:
+            rng = JavaUtilRNGSupplier()
+        valueFunction = cast(
+            "org.spectrumauctions.sats.core.bidlang.xor.SizeBasedUniqueRandomXOR",
+            bidder.getValueFunction(SizeBasedUniqueRandomXOR, rng),
+        )
+        valueFunction.setDistribution(mean_bundle_size, standard_deviation_bundle_size)
+        valueFunction.setIterations(number_of_bids)
+        xorBidIterator = valueFunction.iterator()
+        bids = []
+        while xorBidIterator.hasNext():
+            bundleValue = xorBidIterator.next()
+            bid = []
+            for good_id, good in self.goods.items():
+                bid.append(bundleValue.getBundle().countGood(self.goods[good_id]))
+            bid.append(bundleValue.getAmount().doubleValue())
+            bids.append(bid)
+        return bids
+
+    def _vector_to_bundle(self, vector):
+        assert len(vector) == len(self.goods.keys())
+        bundleEntries = HashSet()
+        for i in range(len(vector)):
+            if vector[i] > 0:
+                bundleEntries.add(BundleEntry(self.goods[i], vector[i]))
+        return Bundle(bundleEntries)
+
+    def get_model_name(self):
+        return super.get_model_name() + "_generic"
+    
+    def get_capacities(self):
+        """
+        Returns a hasmap from good id -> total capacity
+        """
+        capacities = {i: len(self.good_to_licence[i]) for i in range(len(self.good_to_licence))}
+        return capacities

--- a/pysats/pysats.py
+++ b/pysats/pysats.py
@@ -72,16 +72,23 @@ class PySats:
         number_of_regional_bidders=4,
         number_of_local_bidders=3,
         store_files=False,
+        generic=False
     ):
         from .mrvm import _Mrvm
 
-        return _Mrvm(
+        mrvm = _Mrvm(
             seed,
             number_of_national_bidders,
             number_of_regional_bidders,
             number_of_local_bidders,
             store_files,
         )
+
+        if generic:
+            from .generic_wrapper import GenericWrapper
+            return GenericWrapper(mrvm)
+
+        return mrvm
 
     def create_srvm(
         self,
@@ -91,10 +98,11 @@ class PySats:
         number_of_secondary_bidders=2,
         number_of_primary_bidders=2,
         store_files=False,
+        generic=False
     ):
         from .srvm import _Srvm
 
-        return _Srvm(
+        srvm = _Srvm(
             seed,
             number_of_small_bidders,
             number_of_high_frequency_bidders,
@@ -102,3 +110,9 @@ class PySats:
             number_of_primary_bidders,
             store_files,
         )
+
+        if generic:
+            from .generic_wrapper import GenericWrapper
+            return GenericWrapper(srvm)
+
+        return srvm

--- a/tests/test_mrvm.py
+++ b/tests/test_mrvm.py
@@ -408,6 +408,65 @@ class MrvmTest(unittest.TestCase):
             goods_of_interest = mrvm.get_goods_of_interest(bidder_id)
             print(f"Bidder_{bidder_id}: {goods_of_interest}")
 
+    def test_generic(self):
+
+        print('--- Starting MRVM test ---')
+        # create an MRVM instance
+        mrvm = PySats.getInstance().create_mrvm(1)
+        # use the GenericWrapper which uses goods with multiple items per good
+        # a bundle is not anymore a binary vector but a vector of integers
+        mrvm_generic = PySats.getInstance().create_mrvm(1, generic=True)
+
+        # Number of goods in original pySats: 98
+        self.assertEqual(len(mrvm.get_good_ids()), 98)
+        # Number of goods in GenericWrapper: 42
+        self.assertEqual(len(mrvm_generic.get_good_ids()),42)
+
+        # the GenericWrapper has additional attributes that allow to map goods to licences (single items):
+        # i.e. licence with id 2 (pysats) maps to good with id 7 (generic wrapper)
+        self.assertEqual(mrvm_generic.licence_to_good[2], 7)  # maps 98 licenses to 42 goods
+        # i.e the good with id 7 (generic wrapper) maps to licences 2 and 16 (pysats)
+        self.assertEqual(mrvm_generic.good_to_licence[7], [2, 16])
+
+        # keys: goods, values: however many goods map to it
+        capacities = {i: len(mrvm_generic.good_to_licence[i]) for i in range(len(mrvm_generic.good_to_licence))}
+        capacities2 = mrvm_generic.get_capacities()
+
+        # compare the efficient allocation
+        mrvm_eff = mrvm.get_efficient_allocation()
+        mrvm_generic_eff = mrvm_generic.get_efficient_allocation()
+
+        # efficient values are the same
+        self.assertEqual(mrvm_eff[1], mrvm_generic_eff[1])
+
+        # bidder allocation of original pysats (good refers to a licence)
+        print(mrvm_eff[0][1])
+        # bidder allocation of generic wrapper (good refers to generic good), allocation contains additional good_count
+        # (i.e. number of goods allocated in the same order as good_ids)
+        print(mrvm_generic_eff[0][1])
+
+        # perform a demand query
+        price = np.zeros(len(mrvm_generic.get_good_ids()))
+        demand = mrvm_generic.get_best_bundles(1, price, 2, allow_negative=True)
+
+        # random queries work as expected
+        bid = mrvm_generic.get_uniform_random_bids(1, 1)[0]
+
+        value = mrvm_generic.calculate_value(1, demand[0])
+
+        # ensuring that the value in 2 represetations is the same
+        bundle_extended_representation = [0 for i in range(len(mrvm.get_good_ids()))]
+        for i in range(len(demand[0])):
+            license_mapping = mrvm_generic.good_to_licence[i]
+            items_requested = demand[0][i]
+            for j in range(items_requested):
+                bundle_extended_representation[license_mapping[j]] = 1
+
+        value_extended_representation = mrvm.calculate_value(1, bundle_extended_representation)
+
+        self.assertEqual(value, value_extended_representation)
+        print('Difference between the values in the 2 representations:', value - value_extended_representation)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds full support for generic domains in PySats including demand queries. When creating an instance of MRVM or SRVM you may set the "generic" parameter to true to create a generic domain (analogous to the original SATS).

The generic model provides the same functionality as the PySats SimpleModel by representing a bundle as an array of integers instead of an array of {0,1}. Additionally, it provides the following functions and properties:

- licence_to_good: dictionary that maps each licence id of the non-generic model to the id of the generic good. This allows to transform a bundle from a non-generic model into a generic model bundle.
- good_to_licence: dictionary that maps each good id to the corresponding lists of non-generic licences. This allows to transform a bundle from a generic model into a non-geric model bundle.
- get_capacities() dictionary that maps each good it to the corresponding supplied quantity of this good  